### PR TITLE
fix: 修复小程序端（示例钉钉）后台请求返回状态码错误时，不能正常获取状态码的问题

### DIFF
--- a/src/methods/request.ts
+++ b/src/methods/request.ts
@@ -56,9 +56,9 @@ const request: Method = (config, options) => {
             )
           }
           if (isStatusError) {
-            const { statusCode }: any = error ?? {}
+            const response: any = error ?? {}
             reject(
-              new AxiosError(errMsg, statusCode, responseConfig, task, error as unknown as AxiosResponse),
+              new AxiosError(errMsg, response.statusCode, responseConfig, task, response),
             )
           }
         }

--- a/src/methods/request.ts
+++ b/src/methods/request.ts
@@ -20,7 +20,7 @@ const request: Method = (config, options) => {
       success(result) {
         if (!task)
           return
-        
+
         // 兼容钉钉安卓返回的header格式
         if (Array.isArray(result.header)) {
           const dingHeader = {}
@@ -44,6 +44,7 @@ const request: Method = (config, options) => {
       fail(error) {
         const { errMsg = '' } = error ?? {}
         if (errMsg) {
+          const isStatusError = errMsg === 'request:fail http status error'
           const isTimeoutError = errMsg === 'request:fail timeout'
           const isNetworkError = errMsg === 'request:fail'
           if (isTimeoutError)
@@ -52,6 +53,12 @@ const request: Method = (config, options) => {
           if (isNetworkError) {
             reject(
               new AxiosError(errMsg, AxiosError.ERR_NETWORK, responseConfig, task),
+            )
+          }
+          if (isStatusError) {
+            const { statusCode }: any = error ?? {}
+            reject(
+              new AxiosError(errMsg, statusCode, responseConfig, task, error as unknown as AxiosResponse),
             )
           }
         }


### PR DESCRIPTION
fix #65 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP error handling so failed requests now surface accurate HTTP status codes and clearer failure reports instead of generic messages. This makes network error feedback more precise for users and integrations while preserving existing timeout and network error behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->