### PR TITLE
fix: 修复钉钉小程序（钉钉内部应用），在ios平台下返回非标准格式响应，导致不能正常获取到状态码的问题

### DIFF
--- a/src/methods/request.ts
+++ b/src/methods/request.ts
@@ -62,7 +62,8 @@ const request: Method = (config, options) => {
             )
           }
         }
-        reject(new AxiosError(error.errMsg, (error as any)?.statusCode, responseConfig, task, error as any))
+        const failResponse = { ...(error as any), status: (error as any)?.statusCode }
+        reject(new AxiosError(errMsg, failResponse.status, responseConfig, task, failResponse))
         task = null
       },
       complete() {

--- a/src/methods/request.ts
+++ b/src/methods/request.ts
@@ -62,7 +62,7 @@ const request: Method = (config, options) => {
             )
           }
         }
-        reject(new AxiosError(error.errMsg, undefined, responseConfig, task))
+        reject(new AxiosError(error.errMsg, (error as any)?.statusCode, responseConfig, task, error as any))
         task = null
       },
       complete() {


### PR DESCRIPTION
修复bug https://github.com/uni-helper/axios-adapter/issues/75

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP request error responses now include proper status codes and additional error details for better diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uni-helper/axios-adapter/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->